### PR TITLE
doc: Update example config to use IPv4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 # Socket ======================================================================
 # TCP hostname to listen on
-NORAY_SOCKET_HOST=0.0.0.0
+NORAY_SOCKET_HOST=::1
 # TCP port to listen on
 NORAY_SOCKET_PORT=8890
 
 # HTTP ========================================================================
 # HTTP hostname to listen on
-NORAY_HTTP_HOST=0.0.0.0
+NORAY_HTTP_HOST=::1
 # HTTP port to listen on
 NORAY_HTTP_PORT=8891
 

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 # Socket ======================================================================
 # TCP hostname to listen on
-NORAY_SOCKET_HOST=::1
+NORAY_SOCKET_HOST=0.0.0.0
 # TCP port to listen on
 NORAY_SOCKET_PORT=8890
 
 # HTTP ========================================================================
 # HTTP hostname to listen on
-NORAY_HTTP_HOST=::1
+NORAY_HTTP_HOST=0.0.0.0
 # HTTP port to listen on
 NORAY_HTTP_PORT=8891
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Or run prebuilt docker:
 docker run -p 8090:8090 -p 8091:8091 --env-file=.env -t ghcr.io/foxssake/noray:main
 ```
 
+#### EADDRNOTAVAIL
+
+If you get an `EADDRNOTAVAIL` error when trying to listen on an IPv6 address,
+you either need to [enable IPv6 in Docker], or choose an IPv4 host address to
+listen on, e.g. '0.0.0.0' or 'localhost'.
+
+[enable IPv6 in Docker]: https://docs.docker.com/config/daemon/ipv6/
+
 ## Documentation
 
 ### Protocol

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/noray",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Online multiplayer orchestrator and potential game platform",
   "main": "src/noray.mjs",
   "bin": {


### PR DESCRIPTION
### 📓 Description

<!--
  Please describe the contents of the PR in a few sentences / bullet points.
-->

Use 0.0.0.0 as default host instead of ::1 in example config. We're using udp4 sockets, so an IPv6 address is not the best example.

### ☑️ Checklist

<!--
  Please make sure all these items are done / not needed and tick the boxes
  accordingly.
-->

- [x] Documentation is up to date
- [x] Versions are bumped as needed

### 🔗 Related issues

<!--
Please add any and all related issues or N/A for none
-->
N/A