### PR TITLE
fix: Docker expose protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:18-alpine
 # From https://github.com/pnpm/pnpm/issues/4837
 
-EXPOSE 8890/tcp
-EXPOSE 8891/udp
+EXPOSE 8890/udp
+EXPOSE 8891/tcp
 
 COPY . noray
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/noray",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Online multiplayer orchestrator and potential game platform",
   "main": "src/noray.mjs",
   "bin": {


### PR DESCRIPTION
### 📓 Description

<!--
  Please describe the contents of the PR in a few sentences / bullet points.
-->

Dockerfile exposed port 8890 as TCP and 8891 as UDP. Fixed protocols, as noray uses 8890 for UDP and 8891 for TCP.

### ☑️ Checklist

<!--
  Please make sure all these items are done / not needed and tick the boxes
  accordingly.
-->

- [x] Documentation is up to date
- [x] Versions are bumped as needed

### 🔗 Related issues

<!--
Please add any and all related issues or N/A for none
-->
N/A