### PR TITLE
fix: Dockerfile port protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM node:18-alpine
 # From https://github.com/pnpm/pnpm/issues/4837
 
+# UDP host for remote address registration
+EXPOSE 8809/udp
+# TCP host for commands
 EXPOSE 8890/tcp
+# HTTP host for Prometheus metrics
 EXPOSE 8891/tcp
 
 COPY . noray

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-alpine
 # From https://github.com/pnpm/pnpm/issues/4837
 
-EXPOSE 8890/udp
+EXPOSE 8890/tcp
 EXPOSE 8891/tcp
 
 COPY . noray
@@ -16,7 +16,7 @@ RUN npm i -g npm@latest; \
  mkdir -p /usr/local/share/pnpm &&\
  export PNPM_HOME="/usr/local/share/pnpm" &&\
  export PATH="$PNPM_HOME:$PATH"; \
- pnpm bin -g &&\
+ pnpm bin -g && \
  # Install dependencies
  pnpm install
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/noray",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Online multiplayer orchestrator and potential game platform",
   "main": "src/noray.mjs",
   "bin": {


### PR DESCRIPTION
### 📓 Description

<!--
  Please describe the contents of the PR in a few sentences / bullet points.
-->
Fixes Dockerfile exposed port protocol. Port 8891 is the HTTP server for Prometheus metrics, 8890 is the TCP server for commands.

All other ports are configured and run UDP traffic for relays.

### ☑️ Checklist

<!--
  Please make sure all these items are done / not needed and tick the boxes
  accordingly.
-->

- [x] Documentation is up to date
- [x] Versions are bumped as needed

### 🔗 Related issues

<!--
Please add any and all related issues or N/A for none
-->
N/A