### PR TITLE
chore: Upgrade to node v24.16.0

### DIFF
--- a/.github/actions/setup.node/action.yml
+++ b/.github/actions/setup.node/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'node.js version'
     required: false
-    default: 18.x
+    default: 24.x
   pnpm-version:
     description: 'pnpm version'
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  node-version: 18.x
+  node-version: 24.x
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:24-alpine
 # From https://github.com/pnpm/pnpm/issues/4837
 
 # UDP host for remote address registration

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:24-alpine
-# From https://github.com/pnpm/pnpm/issues/4837
+FROM ghcr.io/pnpm/pnpm:11
 
 # UDP host for remote address registration
 EXPOSE 8809/udp
@@ -8,20 +7,8 @@ EXPOSE 8890/tcp
 # HTTP host for Prometheus metrics
 EXPOSE 8891/tcp
 
-COPY . noray
+COPY . /foxssake/noray
+WORKDIR /foxssake/noray
+RUN pnpm install --frozen-lockfile
 
-WORKDIR noray
-
-RUN npm i -g npm@latest; \
- # Install pnpm
- npm install -g pnpm; \
- pnpm --version; \
- pnpm setup; \
- mkdir -p /usr/local/share/pnpm &&\
- export PNPM_HOME="/usr/local/share/pnpm" &&\
- export PATH="$PNPM_HOME:$PATH"; \
- pnpm bin -g && \
- # Install dependencies
- pnpm install
-
-CMD pnpm start:prod
+CMD ["pnpm", "start:prod"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ transmitted as-is to the appropriate player.
 
 ## Dependencies
 
-* [node](https://nodejs.org/en/download) v18.16 or newer
+* [node](https://nodejs.org/en/download) v24.16 or newer
   * *NOTE:* Older versions may work, but are not explicitly supported
 * [pnpm](https://pnpm.io/installation)
 

--- a/package.json
+++ b/package.json
@@ -1,54 +1,57 @@
 {
-  "name": "@foxssake/noray",
-  "version": "1.5.1",
-  "description": "Online multiplayer orchestrator and potential game platform",
-  "main": "src/noray.mjs",
-  "bin": {
-    "noray": "bin/noray.mjs"
-  },
-  "scripts": {
-    "lint": "eslint --ext .mjs src",
-    "doc": "jsdoc -c .jsdoc.js src",
-    "test": "node --test test/spec/",
-    "test:e2e": "node --test test/e2e/ | node scripts/taplog.mjs utap \"pino-pretty -c\"",
-    "start": "node bin/noray.mjs | pino-pretty",
-    "start:prod": "NODE_ENV=production node bin/noray.mjs"
-  },
-  "keywords": [
-    "online",
-    "multiplayer",
-    "orchestrator",
-    "relay",
-    "nat"
-  ],
-  "author": "Tamas Galffy",
-  "license": "MIT",
-  "repository": "github:foxssake/noray",
-  "homepage": "https://github.com/foxssake/noray",
-  "bugs": {
-    "url": "https://github.com/foxssake/noray/issues"
-  },
-  "devDependencies": {
-    "eslint": "^8.36.0",
-    "eslint-config-standard": "^17.0.0",
-    "eslint-plugin-import": "^2.25.2",
-    "eslint-plugin-n": "^15.0.0",
-    "eslint-plugin-promise": "^6.0.0",
-    "jsdoc": "^4.0.2",
-    "pino-pretty": "^10.0.0",
-    "sinon": "^15.0.4",
-    "utap": "^0.2.0"
-  },
-  "dependencies": {
-    "@foxssake/trimsock-js": "^0.17.0",
-    "@foxssake/trimsock-node": "^0.17.0",
-    "dotenv": "^16.0.3",
-    "nanoid": "^4.0.1",
-    "pino": "^8.11.0",
-    "prom-client": "^14.2.0"
-  },
-  "files": [
-    "src/*",
-    "bin/*"
-  ]
+	"name": "@foxssake/noray",
+	"version": "1.5.2",
+	"description": "Online multiplayer orchestrator and potential game platform",
+	"main": "src/noray.mjs",
+	"bin": {
+		"noray": "bin/noray.mjs"
+	},
+	"scripts": {
+		"lint": "eslint --ext .mjs src",
+		"doc": "jsdoc -c .jsdoc.js src",
+		"test": "node --test test/spec/",
+		"test:e2e": "node --test test/e2e/ | node scripts/taplog.mjs utap \"pino-pretty -c\"",
+		"start": "node bin/noray.mjs | pino-pretty",
+		"start:prod": "NODE_ENV=production node bin/noray.mjs"
+	},
+	"keywords": [
+		"online",
+		"multiplayer",
+		"orchestrator",
+		"relay",
+		"nat"
+	],
+	"author": "Tamas Galffy",
+	"license": "MIT",
+	"repository": "github:foxssake/noray",
+	"homepage": "https://github.com/foxssake/noray",
+	"bugs": {
+		"url": "https://github.com/foxssake/noray/issues"
+	},
+	"devDependencies": {
+		"eslint": "^8.36.0",
+		"eslint-config-standard": "^17.0.0",
+		"eslint-plugin-import": "^2.25.2",
+		"eslint-plugin-n": "^15.0.0",
+		"eslint-plugin-promise": "^6.0.0",
+		"jsdoc": "^4.0.2",
+		"pino-pretty": "^10.0.0",
+		"sinon": "^15.0.4",
+		"utap": "^0.2.0"
+	},
+	"dependencies": {
+		"@foxssake/trimsock-js": "^0.17.0",
+		"@foxssake/trimsock-node": "^0.17.0",
+		"dotenv": "^16.0.3",
+		"nanoid": "^4.0.1",
+		"pino": "^8.11.0",
+		"prom-client": "^14.2.0"
+	},
+	"engines": {
+		"node": ">=24.16.0"
+	},
+	"files": [
+		"src/*",
+		"bin/*"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,12 @@
 		"pino": "^8.11.0",
 		"prom-client": "^14.2.0"
 	},
-	"engines": {
-		"node": ">=24.16.0"
+	"devEngines": {
+		"runtime": {
+			"name": "node",
+			"version": "24.x",
+			"onFail": "download"
+		}
 	},
 	"files": [
 		"src/*",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 	"scripts": {
 		"lint": "eslint --ext .mjs src",
 		"doc": "jsdoc -c .jsdoc.js src",
-		"test": "node --test test/spec/",
-		"test:e2e": "node --test test/e2e/ | node scripts/taplog.mjs utap \"pino-pretty -c\"",
+		"test": "node --test test/spec/**/*.test.ts",
+		"test:e2e": "node --test test/e2e/**/*.test.ts | node scripts/taplog.mjs utap \"pino-pretty -c\"",
 		"start": "node bin/noray.mjs | pino-pretty",
 		"start:prod": "NODE_ENV=production node bin/noray.mjs"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
+      node:
+        specifier: runtime:24.x
+        version: runtime:24.16.0
       pino-pretty:
         specifier: ^10.0.0
         version: 10.3.1
@@ -149,6 +152,9 @@ packages:
 
   '@sinonjs/text-encoding@0.7.3':
     resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
+    deprecated: |-
+      Deprecated: no longer maintained and no longer used by Sinon packages. See
+        https://github.com/sinonjs/nise/issues/243 for replacement details.
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -164,6 +170,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -594,7 +601,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -881,6 +888,127 @@ packages:
 
   nise@5.1.9:
     resolution: {integrity: sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==}
+
+  node@runtime:24.16.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-MN/Y5EMiwnEoE/JeFjwlPK1TvkPgmJB7i1NIvxdKSWg=
+            type: binary
+            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-ORidq07rFXBsQkrwrAijBEyeSPfbEqfXf2t6r8fdXfY=
+            type: binary
+            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-KYtMezy4B2XIcD5CuQMkpOzjtmNJR7iedpw8mAq1UYU=
+            type: binary
+            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-WJ9bbdT8/uTf2nMBOQPJZquqir2T28nUNlRORytPDnQ=
+            type: binary
+            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-JStYIFNNwDBKKFQcmkRDfPpyAufyAiXSjUk5MsWOl6o=
+            type: binary
+            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-Vnrwl1s0BVFrmx3cZEKaI+yMWi+mzwE5EmGkzHdOPt0=
+            type: binary
+            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-L69qOH6bYriI4hxU8BJJ+ydTf/7PGELyn0yRnQpZoP8=
+            type: binary
+            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-FINGEdTGs8BgVOcAdzK5BHTBbgsy85XgW1Wlce9xxtI=
+            prefix: node-v24.16.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-7aypvVjsjpIDfaxOh31S9rj0MLgcGLV+JktOL7ERzVY=
+            prefix: node-v24.16.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-hd3ieqc1A7A9rfoEEKgABntOP3Avt/yqO+ryhN/Maek=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64-musl.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-UN9djUdIktT3uQYWffNvd/W5OQj2PcUy3FaCGcq2WEE=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+    version: 24.16.0
+    hasBin: true
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2204,6 +2332,8 @@ snapshots:
       '@sinonjs/text-encoding': 0.7.3
       just-extend: 6.2.0
       path-to-regexp: 6.3.0
+
+  node@runtime:24.16.0: {}
 
   object-inspect@1.13.4: {}
 


### PR DESCRIPTION
### 📓 Description

<!--
  Please describe the contents of the PR in a few sentences / bullet points.
-->

Upgrades the required node version from 18.x to 24.16.0 at least. This enables a follow-up PR, rewriting noray to typescript, which can then be natively ran by node 24.

### ☑️ Checklist

<!--
  Please make sure all these items are done / not needed and tick the boxes
  accordingly.
-->

- [x] Documentation is up to date
- [x] Versions are bumped as needed

### 🔗 Related issues

<!--
Please add any and all related issues or N/A for none
-->

N/A
