### PR TITLE
fix(relay): don't exit when a UDP reply bounces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foxssake/noray",
-	"version": "1.5.4",
+	"version": "1.5.5",
 	"description": "Network connection orchestrator",
 	"main": "src/noray.ts",
 	"type": "module",

--- a/src/relay/udp.remote.registrar.ts
+++ b/src/relay/udp.remote.registrar.ts
@@ -65,6 +65,9 @@ export class UDPRemoteRegistrar {
         data: (_socket, data, port, address) => {
           this.handle(data, address, port);
         },
+        error: (_socket, error) => {
+          log.error(error, "UDP registrar socket encountered an error!");
+        },
       },
     });
 


### PR DESCRIPTION
### 📓 Description

A single UDP packet from any source can stop noray.

`UDPRemoteRegistrar.listen()` creates its socket with a `data` handler but no
`error` handler. When a packet arrives that is not a valid PID, `handle()`
catches the assertion and **replies with the error message**. If the sender has
gone — a port scanner, a stray packet, a client that has moved on — that reply
provokes an ICMP port-unreachable, which surfaces on the socket as
`ECONNREFUSED`. With no handler, Bun treats it as fatal and the process exits.

Reproduced on 1 August 2026 against `c0c34dc`, with `NORAY_UDP_REGISTRAR_PORT`
reachable from the internet:

```
printf 'not-a-pid' | nc -u -w1 <host> 8809
```

```
ECONNREFUSED: connection refused, recv
 syscall: "recv", errno: -111
Shutting down
noray.service: Main process exited, code=exited, status=1/FAILURE
```

systemd restarted it and the next stray packet killed it again. In our case it
had been restarting every few seconds for an hour before we noticed, which made
every other measurement meaningless — ports appeared closed, join codes were
issued and then were not, and nothing reproduced twice.

The fix copies the handler `bindPortForRelaying` already installs on the relay
sockets in `src/relay/relay.ts`. After it, the same packet logs a line and the
process carries on:

```
{"level":50,"name":"UDPRemoteRegistrar","msg":"UDP registrar socket encountered an error!"}
```

Verified against a live instance: the packet that previously killed it, then an
empty packet, binary junk, a 2KB payload and a TCP command sent over UDP — all
logged, same PID throughout, and the instance kept issuing OIDs between them.

### ☑️ Checklist

- [x] Documentation is up to date — no user-facing change
- [x] Versions are bumped as needed — no API change

### 🔗 Related issues

Partially addresses #74 — this is one of the "thrown inside an event handler"
cases. Same family as #54.

Happy to widen it to the other sockets in the relay module if you would rather
have that in one go, but I have only reproduced this one.